### PR TITLE
feat(cli): add task manager skeleton with 'add' command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
-temp/
+node_modules/
 *.log
+.DS_Store
+temp/

--- a/README.md
+++ b/README.md
@@ -3,3 +3,13 @@ first github project
 
 ## Project Goal
 # Practive Git Hub basics
+
+## Task Manager CLI (Node.js)
+A simple command-line tool to manage tasks stored in `tasks.json`.
+
+### Install & Run
+- Requires Node.js and npm.
+
+### Commands
+- `node src/index.js help` — show help
+- `node src/index.js add "Task title"` — add a task

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "hello-git",
+  "version": "1.0.0",
+  "description": "first github project",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/rajnagaboina/hello-git.git"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "bugs": {
+    "url": "https://github.com/rajnagaboina/hello-git/issues"
+  },
+  "homepage": "https://github.com/rajnagaboina/hello-git#readme"
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,81 @@
+//!/usr/bin/env node
+/**
+ * Task Manager CLI — Feature 1 (add + help)
+ * Stores tasks in tasks.json at repo root.
+ *
+ * Usage:
+ *   node src/index.js help
+ *   node src/index.js add "Task title"
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const DB_PATH = path.join(__dirname, '..', 'tasks.json');
+
+function ensureDb() {
+  if (!fs.existsSync(DB_PATH)) {
+    fs.writeFileSync(DB_PATH, '[]', 'utf-8');
+  }
+}
+
+function loadTasks() {
+  ensureDb();
+  const text = fs.readFileSync(DB_PATH, 'utf-8').trim() || '[]';
+  return JSON.parse(text);
+}
+
+function saveTasks(tasks) {
+  fs.writeFileSync(DB_PATH, JSON.stringify(tasks, null, 2), 'utf-8');
+}
+
+function nextId(tasks) {
+  return tasks.reduce((max, t) => Math.max(max, t.id || 0), 0) + 1;
+}
+
+function addTask(title) {
+  if (!title || !title.trim()) {
+    console.error('❌ Please provide a task title, e.g.:');
+    console.error('   node src/index.js add "Buy milk"');
+    process.exit(1);
+  }
+  const tasks = loadTasks();
+  const task = {
+    id: nextId(tasks),
+    title: title.trim(),
+    done: false,
+    createdAt: new Date().toISOString(),
+  };
+  tasks.push(task);
+  saveTasks(tasks);
+  console.log(`✅ Added task #${task.id}: ${task.title}`);
+}
+
+function showHelp() {
+  console.log(`
+Task Manager CLI
+
+Commands:
+  node src/index.js help
+  node src/index.js add "Task title"
+
+Examples:
+  node src/index.js add "Buy groceries"
+  node src/index.js add "Read 10 pages"
+  `);
+}
+
+function main() {
+  const [, , cmd, ...args] = process.argv;
+  switch ((cmd || 'help').toLowerCase()) {
+    case 'add':
+      addTask(args.join(' '));
+      break;
+    case 'help':
+    default:
+      showHelp();
+      break;
+  }
+}
+
+main();

--- a/tasks.json
+++ b/tasks.json
@@ -1,0 +1,14 @@
+[
+  {
+    "id": 1,
+    "title": "Buy groceries",
+    "done": false,
+    "createdAt": "2026-03-04T03:49:47.525Z"
+  },
+  {
+    "id": 2,
+    "title": "Read 10 pages",
+    "done": false,
+    "createdAt": "2026-03-04T03:49:58.326Z"
+  }
+]


### PR DESCRIPTION
Implements a minimal CLI in Node.js with an `add` command that persists tasks to tasks.json.

Closes #<issue-number>